### PR TITLE
[codex] Document cutover readiness blocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ yarn dev
 
 ## Deployment Setup (Cloudflare Pages)
 
-Project: `blog-hichee-com`  
+Project: `blog-hichee-com`
 Current Pages URL: `https://blog-hichee-com-git.pages.dev`
+Current staging/cutover URL: `https://newblog.hichee.com`
 
 This project is connected to GitHub (`shakacode/blog.hichee.com`) in Cloudflare Pages.
 
@@ -60,6 +61,7 @@ node scripts/create-draft-issues.mjs --apply
 
 ## Staging and Cutover Plan
 
-- Stage site on `newblog.hichee.com` via Cloudflare Pages.
-- Run QA checklist (links, SEO, images, page templates, redirects, performance).
+- `newblog.hichee.com` is the Cloudflare Pages staging site.
+- Run QA checklist (links, SEO, images, page templates, redirects, performance) against `newblog.hichee.com` and the current live WordPress site at `blog.hichee.com`.
 - Freeze WordPress edits, run final delta sync, then switch `blog.hichee.com`.
+- Do not switch `blog.hichee.com` until the old WordPress origin has a backup hostname and `LEGACY_MEDIA_ORIGIN` is set to that hostname in the Pages production environment.

--- a/docs/cloudflare-rollout.md
+++ b/docs/cloudflare-rollout.md
@@ -7,13 +7,16 @@
 - Staging custom domain: `newblog.hichee.com`.
 - Production custom domain: `blog.hichee.com`.
 
-## Current Status (2026-02-24)
+## Current Status (2026-04-23)
 
 - Pages project created: `blog-hichee-com`.
 - Project is Git-connected to `shakacode/blog.hichee.com` (Cloudflare Git Provider: Yes).
-- Successful Git-connected deployment completed: `https://0c10c0d4.blog-hichee-com-git.pages.dev`.
-- Staging custom domain `newblog.hichee.com` added to project but still pending verification.
-- Pending DNS step: create CNAME record `newblog -> blog-hichee-com-git.pages.dev` in `hichee.com` zone.
+- Active production deployment source: `def69eb`.
+- Active production deployment URL: `https://47bd19d6.blog-hichee-com-git.pages.dev`.
+- Current Pages project domains: `blog-hichee-com-git.pages.dev`, `newblog.hichee.com`.
+- `blog.hichee.com` is not attached to the Pages project yet.
+- The Pages production config currently has `LEGACY_MEDIA_ORIGIN` set to an empty string.
+- DNS-record inspection is not available through the current API token permissions, so clone the existing `blog.hichee.com` WordPress origin in the Cloudflare dashboard before cutover.
 
 ## Recommended Sequence
 
@@ -26,15 +29,21 @@
 4. Validate content, links, SEO, and media on staging.
 5. Freeze WordPress edits.
 6. Run final migration/export pass.
-7. Promote by attaching/switching `blog.hichee.com` to this Pages project.
-8. Verify and monitor.
+7. Create a backup hostname for the old WordPress origin, for example `oldblog.hichee.com`.
+8. Verify the backup hostname serves the old WordPress site, including `/wp-content/*` media.
+9. Set Pages production variable `LEGACY_MEDIA_ORIGIN=https://oldblog.hichee.com` and redeploy.
+10. Verify missing-media fallback on `newblog.hichee.com` after the redeploy.
+11. Promote by attaching/switching `blog.hichee.com` to this Pages project.
+12. Verify and monitor.
 
 ## Notes
 
 - If DNS is managed in the same Cloudflare account, CNAME creation can be automatic. If token/account permissions are limited, create the CNAME manually in dashboard DNS.
 - For this project, deploys are now handled by Cloudflare Pages Git integration (not a custom GitHub Action deploy workflow).
+- The actual cutover is attaching/switching `blog.hichee.com`; do not perform that step without final confirmation.
 
 ## Rollback
 
 - Keep WordPress origin intact until stable after cutover.
 - If critical issue appears, switch DNS/custom domain back to WordPress origin.
+- Keep the WordPress backup hostname online until R2 media coverage is complete and enough production traffic has warmed the cache.

--- a/docs/media-strategy.md
+++ b/docs/media-strategy.md
@@ -38,3 +38,12 @@ CLOUDFLARE_ACCOUNT_ID=<account-id> yarn migrate:media:sync:r2
 - Before DNS cutover, `newblog.hichee.com` and preview branches can safely fall back to the current live `https://blog.hichee.com` for missing media.
 - Before moving `blog.hichee.com` to the new Pages site, create a backup hostname for the old WordPress instance, then set `LEGACY_MEDIA_ORIGIN` to that backup hostname and redeploy.
 - After cutover, keep the backup hostname online until the R2 bucket has warmed or a full bulk sync is complete.
+
+## Latest Validation
+
+As of 2026-04-23:
+
+- Built-site media manifest contains 21,002 unique `/wp-content/*` keys.
+- Full parity against `https://blog.hichee.com` and `https://newblog.hichee.com` found no final status or content-type regressions after transient retries.
+- Generated `dist/` output contains no absolute `blog.hichee.com/wp-content` references; public pages use root-relative media URLs.
+- Cutover is still blocked until `LEGACY_MEDIA_ORIGIN` points at a verified backup WordPress hostname, because once `blog.hichee.com` serves the Pages site it can no longer be used as the fallback origin for missing R2 objects.

--- a/docs/staging-test-plan.md
+++ b/docs/staging-test-plan.md
@@ -1,7 +1,7 @@
 # Staging Test Plan (newblog.hichee.com)
 
-Current preview deployment: `https://0c10c0d4.blog-hichee-com-git.pages.dev`  
-Custom domain status: `newblog.hichee.com` pending DNS CNAME verification.
+Current production deployment: `https://47bd19d6.blog-hichee-com-git.pages.dev`
+Current custom domain status: `newblog.hichee.com` is live on the Cloudflare Pages project.
 
 ## 1) Content Parity
 
@@ -41,11 +41,14 @@ Custom domain status: `newblog.hichee.com` pending DNS CNAME verification.
 - No major SEO regressions.
 - Cutover and rollback commands prepared and rehearsed.
 
-## Current Execution Status (2026-02-24)
+## Current Execution Status (2026-04-23)
 
 - [x] Astro build succeeds locally (`yarn build`).
 - [x] Pages deployment succeeds (`blog-hichee-com`).
-- [x] Root path returns `200` on preview.
-- [x] Sample migrated article paths return `200` on preview.
-- [ ] `newblog.hichee.com` returns `200` (waiting for CNAME DNS record).
-- [ ] Full SEO/asset QA sweep completed.
+- [x] Root path returns `200` on `newblog.hichee.com`.
+- [x] Sample migrated article paths return `200` on `newblog.hichee.com`.
+- [x] `newblog.hichee.com` returns `200`.
+- [x] Full generated-route HTTP sweep completed: 713 generated routes checked, with only intentional redirects.
+- [x] Full media parity completed: 21,002 `/wp-content/*` keys checked with no final status or content-type regressions.
+- [x] Mobile and desktop smoke checks passed for home, host page, author archives, legacy aliases, pagination, share controls, and media.
+- [ ] Final DNS cutover is blocked until the old WordPress origin has a backup hostname and Pages production `LEGACY_MEDIA_ORIGIN` points to it.


### PR DESCRIPTION
## Summary

Updates the migration docs to reflect the current live staging state after the latest Cloudflare Pages deployment.

- Records `newblog.hichee.com` as live on the Pages project.
- Records the active production deploy source `def69eb` and deployment URL.
- Documents that `blog.hichee.com` is not attached to Pages yet.
- Makes the remaining DNS cutover blocker explicit: create a backup hostname for the old WordPress origin, set `LEGACY_MEDIA_ORIGIN` to that hostname, redeploy, then switch `blog.hichee.com` only after final confirmation.
- Captures the latest route/media/browser validation results used for cutover readiness.

## Validation

- `git diff --check`
- `yarn build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify rollout status and cutover prerequisites; no runtime code or configuration changes are included.
> 
> **Overview**
> Updates migration/runbook docs to reflect the current Cloudflare Pages staging state, including `newblog.hichee.com` being live and the active deployment details.
> 
> Makes the production cutover blocker explicit: **create a backup hostname for the legacy WordPress origin, set `LEGACY_MEDIA_ORIGIN` to it, redeploy, then attach/switch `blog.hichee.com`**. Adds the latest staging validation results (route sweep/media parity) and expands rollback notes to keep the backup origin online until R2 coverage/caching is sufficient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f24b9914dfc7c4536ced03c0ef0f151b3a93a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->