### PR TITLE
[codex] Fix share icon alignment

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -727,6 +727,7 @@ a.page-numbers:hover {
   --share-bg: #5f6b7a;
   width: 2.15rem;
   height: 2.15rem;
+  position: relative;
   display: inline-flex !important;
   align-items: center;
   justify-content: center;
@@ -760,14 +761,18 @@ a.page-numbers:hover {
   content: none !important;
 }
 
-.legacy-share-link__icon {
-  display: grid;
-  place-items: center;
-  width: 100%;
-  height: 100%;
+.legacy-share-link > :is(.legacy-share-link__icon, .legacy-share-link__glyph) {
+  position: absolute;
+  inset: 0;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 100% !important;
+  height: 100% !important;
   border-radius: inherit;
-  line-height: 1;
+  line-height: 1 !important;
   pointer-events: none;
+  text-align: center;
 }
 
 .legacy-share-link__icon svg {
@@ -775,6 +780,10 @@ a.page-numbers:hover {
   height: 1.05rem;
   display: block;
   fill: currentColor;
+}
+
+.legacy-share-link__glyph {
+  font: inherit;
 }
 
 .legacy-share-link--facebook {


### PR DESCRIPTION
## Summary

Fixes the final Hosts page share-icon alignment issue by making the generated share icon wrapper explicitly fill each circular button and center its SVG/glyph with flexbox.

This avoids AddToAny's imported `.a2a_kit_size_32` span rules pulling the icon wrapper back to inline-block/line-height behavior, which showed up especially badly in Firefox.

## Validation

- `git diff --check`
- `yarn build`
- Local preview browser geometry check for `/hichee-blog-for-hosts/`:
  - Chrome desktop: 6 icons, max center offset `0px`, hover visible
  - Chrome mobile: 6 icons, max center offset `0px`, hover visible
  - Firefox desktop: 6 icons, max center offset `0px`, hover visible
  - Firefox mobile-width: 6 icons, max center offset `0.001px`, hover visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS changes limited to legacy share button presentation; no logic, data, or security impact.
> 
> **Overview**
> Fixes misaligned legacy share icons by making `.legacy-share-link` a positioned container and forcing its immediate `.legacy-share-link__icon`/`.legacy-share-link__glyph` child to absolutely fill the full circular button and center its SVG/glyph via flexbox.
> 
> This hardens the share button styling against third-party AddToAny span defaults (inline/line-height), improving cross-browser alignment consistency (notably Firefox).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1bd575af7a560fabca6bcda62f73f1d6dc0ee6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->