### PR TITLE
[codex] Document current cutover blocker

### DIFF
--- a/docs/cloudflare-rollout.md
+++ b/docs/cloudflare-rollout.md
@@ -7,16 +7,17 @@
 - Staging custom domain: `newblog.hichee.com`.
 - Production custom domain: `blog.hichee.com`.
 
-## Current Status (2026-04-23)
+## Current Status (2026-04-30)
 
 - Pages project created: `blog-hichee-com`.
 - Project is Git-connected to `shakacode/blog.hichee.com` (Cloudflare Git Provider: Yes).
-- Active production deployment source: `def69eb`.
-- Active production deployment URL: `https://47bd19d6.blog-hichee-com-git.pages.dev`.
+- Last confirmed `main` deploy source: `75c579a` (`Fix share icon alignment (#740)`).
+- GitHub CI push run `25157303550` completed successfully for `75c579a`.
 - Current Pages project domains: `blog-hichee-com-git.pages.dev`, `newblog.hichee.com`.
 - `blog.hichee.com` is not attached to the Pages project yet.
 - The Pages production config currently has `LEGACY_MEDIA_ORIGIN` set to an empty string.
-- DNS-record inspection is not available through the current API token permissions, so clone the existing `blog.hichee.com` WordPress origin in the Cloudflare dashboard before cutover.
+- Candidate backup hostnames checked on 2026-04-30 (`oldblog.hichee.com`, `wp-blog.hichee.com`, `origin-blog.hichee.com`, `wordpress.hichee.com`, `wp.hichee.com`) have no public DNS records yet.
+- Cloudflare dashboard or Wrangler access is required to clone the existing `blog.hichee.com` WordPress origin before cutover.
 
 ## Recommended Sequence
 
@@ -29,8 +30,8 @@
 4. Validate content, links, SEO, and media on staging.
 5. Freeze WordPress edits.
 6. Run final migration/export pass.
-7. Create a backup hostname for the old WordPress origin, for example `oldblog.hichee.com`.
-8. Verify the backup hostname serves the old WordPress site, including `/wp-content/*` media.
+7. Create a backup hostname for the old WordPress origin, for example `oldblog.hichee.com`, using the same target as the current WordPress-backed `blog.hichee.com` DNS record.
+8. Verify the backup hostname serves the old WordPress site directly, including `/wp-content/*` media, and does not redirect back to `blog.hichee.com`.
 9. Set Pages production variable `LEGACY_MEDIA_ORIGIN=https://oldblog.hichee.com` and redeploy.
 10. Verify missing-media fallback on `newblog.hichee.com` after the redeploy.
 11. Promote by attaching/switching `blog.hichee.com` to this Pages project.

--- a/docs/media-strategy.md
+++ b/docs/media-strategy.md
@@ -41,9 +41,10 @@ CLOUDFLARE_ACCOUNT_ID=<account-id> yarn migrate:media:sync:r2
 
 ## Latest Validation
 
-As of 2026-04-23:
+As of 2026-04-30:
 
 - Built-site media manifest contains 21,002 unique `/wp-content/*` keys.
 - Full parity against `https://blog.hichee.com` and `https://newblog.hichee.com` found no final status or content-type regressions after transient retries.
 - Generated `dist/` output contains no absolute `blog.hichee.com/wp-content` references; public pages use root-relative media URLs.
+- A representative migrated media URL returned 200 from both `https://blog.hichee.com/wp-content/uploads/2022/08/Hichee.png` and `https://newblog.hichee.com/wp-content/uploads/2022/08/Hichee.png`.
 - Cutover is still blocked until `LEGACY_MEDIA_ORIGIN` points at a verified backup WordPress hostname, because once `blog.hichee.com` serves the Pages site it can no longer be used as the fallback origin for missing R2 objects.


### PR DESCRIPTION
## Summary
- refresh Cloudflare rollout status to the current 2026-04-30 main deploy
- document that backup WordPress hostnames are not live yet
- clarify the required legacy media origin verification before DNS cutover

## Verification
- git diff --check
- yarn build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no runtime behavior or deployment configuration is modified.
> 
> **Overview**
> Refreshes the Cloudflare rollout docs to the 2026-04-30 status, including the last confirmed `main` deploy SHA and CI run.
> 
> Clarifies the *cutover blocker* by documenting that candidate backup WordPress hostnames have no public DNS yet and that dashboard/Wrangler access is required to clone the existing `blog.hichee.com` origin.
> 
> Tightens the cutover sequence/validation steps to ensure the backup hostname serves WordPress directly (no redirect) and adds a concrete media URL check in the media strategy validation notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323cbf47d3917903409c5c3712eebd9562ce1d6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment tracking and status information
  * Added validation confirming media content serves correctly across all production domains

<!-- end of auto-generated comment: release notes by coderabbit.ai -->