### PR TITLE
[codex] Link footer support contact

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,7 +48,7 @@ const footerSections = [
       { href: 'https://hichee.com/hosts', label: 'Boost Direct Bookings' },
       { href: 'https://hichee.com/listing-verification', label: 'Verify Your Listing' },
       { href: '/hichee-blog-for-hosts/', label: 'Blog For Hosts' },
-      { label: 'HiChee Support' }
+      { href: 'mailto:support@hichee.com', label: 'HiChee Support' }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- make the footer HiChee Support item a functional mailto link

## Verification
- git diff --check
- yarn build
- verified generated homepage and hosts page include mailto:support@hichee.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single footer config change with no auth, data, or routing impact; mailto opens in the same tab by existing link logic.
> 
> **Overview**
> The **Hosting** footer entry **HiChee Support** now includes `href: mailto:support@hichee.com`, so it renders as a clickable anchor instead of plain text (previously the item had only a label and fell through to a `<span>`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a49e290ed472025f36d8049bf9a1e137599f1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->